### PR TITLE
2025.09.12 수정 내용

### DIFF
--- a/Sources/Extensions/Debug+Extension.swift
+++ b/Sources/Extensions/Debug+Extension.swift
@@ -17,12 +17,12 @@ public extension Data {
             let json = try JSONSerialization.jsonObject(with: self, options: [])
             let data = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys, .prettyPrinted])
             guard let jsonString = String(data: data, encoding: .utf8) else {
-                return ""
+                return String(data: self, encoding: .utf8) ?? ""
             }
             return jsonString
         } catch {
             DebugLog("Error: \(error.localizedDescription)")
-            return ""
+            return String(data: self, encoding: .utf8) ?? ""
         }
     }
 }

--- a/Sources/Extensions/String+Extension.swift
+++ b/Sources/Extensions/String+Extension.swift
@@ -397,6 +397,48 @@ public extension String {
         return url.deletingPathExtension().lastPathComponent
     }
 
+    /// 문자열에서 HTML <img> 태그의 src 속성을 찾아 배열로 반환합니다.
+    func extractImageURLs() -> [String] {
+        var imageUrls: [String] = []
+
+        // 정규식: <img ... src="URL" ... > 형태의 태그를 찾습니다.
+        let pattern = "<img\\s+[^>]*src\\s*=\\s*\"([^\"]*)\"[^>]*>"
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return imageUrls
+        }
+
+        // 문자열에서 정규식과 일치하는 모든 결과 찾기
+        let matches = regex.matches(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count))
+
+        for match in matches {
+            // 첫 번째 캡처 그룹(capture group)은 src 속성 값입니다.
+            let nsRange = match.range(at: 1)
+            if let range = Range(nsRange, in: self) {
+                let url = String(self[range])
+                imageUrls.append(url)
+            }
+        }
+
+        return imageUrls
+    }
+
+    /// 문자열에서 HTML 태그를 제거합니다.
+    func stripHTML() -> String {
+        // 정규식: <... > 형태의 모든 태그를 찾습니다.
+        let pattern = "<[^>]+>"
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return self
+        }
+
+        let result = regex.stringByReplacingMatches(in: self, options: [], range: NSRange(location: 0, length: self.utf16.count), withTemplate: "")
+
+        // CDATA 섹션과 같은 특수 문자를 제거합니다.
+        return result
+            .replacingOccurrences(of: "<![CDATA[", with: "")
+            .replacingOccurrences(of: "]]>", with: "")
+    }
 }
 
 public extension Character {

--- a/Sources/Extensions/UIImageView+Extension.swift
+++ b/Sources/Extensions/UIImageView+Extension.swift
@@ -23,13 +23,13 @@ public class CustomKfActivityIndicator: Indicator {
 public extension UIImageView {
 #if canImport(Kingfisher)
     func stopDownloadTask() {
-        self.kf.cancelDownloadTask()
+        kf.cancelDownloadTask()
     }
 
     func setUrlImage(
         _ urlStr: String,
         placeholder: UIImage? = nil,
-        options: KingfisherOptionsInfo? = [ .transition(.fade(0.5))],
+        options: KingfisherOptionsInfo? = [ .transition(.none)],
         imageResize: CGSize? = nil,
         isIndicator: Bool = true,
         indicator: UIActivityIndicatorView = UIActivityIndicatorView(style: .medium)
@@ -48,7 +48,7 @@ public extension UIImageView {
     func setUrlImage(
         _ urlStr: String,
         placeholder: UIImage? = nil,
-        options: KingfisherOptionsInfo? = [ .transition(.fade(0.5))],
+        options: KingfisherOptionsInfo? = [ .transition(.none)],
         imageResize: CGSize? = nil,
         isIndicator: Bool = true,
         indicator: UIActivityIndicatorView = UIActivityIndicatorView(style: .medium),
@@ -76,34 +76,53 @@ public extension UIImageView {
     ) {
 
         // 이미지 초기화 및 다운로드 취소
-        self.stopDownloadTask()
-        if let placeholder = placeholder, self.image == nil {
-            self.image = placeholder
+        stopDownloadTask()
+        if let placeholder = placeholder, image == nil {
+            image = placeholder
         }
 
         guard let url = URL(string: urlStr) else {
-            self.image = nil
+            DebugLog("internalSetUrlImage urlStr is not valid url", level: .error, param: ["urlStr": urlStr])
+            image = nil
             completionHandler?(.failure(KingfisherError.requestError(reason: .emptyRequest)))
             return
         }
 
+        // 기존에 존재할 수 있는 커스텀 인디케이터 뷰를 제거하여 오토 레이아웃 충돌을 방지합니다.
+        kf.indicator?.view.removeFromSuperview()
         var kfOptions = options ?? []
 
+        // ✅ 리사이즈 적용 (없으면 imageView 크기 사용)
+        let targetSize: CGSize
         if let resize = imageResize, resize.width > 0, resize.height > 0 {
-            let processor = DownsamplingImageProcessor(size: resize)
+            targetSize = resize
+        } else {
+            targetSize = bounds.size // 뷰 크기 기준으로 다운샘플링
+        }
+
+        var resizedCacheKey = url.absoluteString
+        if targetSize.width > 0 && targetSize.height > 0 {
+            let processor = DownsamplingImageProcessor(size: targetSize)
             kfOptions.append(.processor(processor))
             kfOptions.append(.scaleFactor(UIScreen.main.scale))
-            kfOptions.append(.cacheOriginalImage)
+            // ✅ 해상도별 cacheKey 생성
+            let sizeKey = "w\(Int(targetSize.width))_h\(Int(targetSize.height))"
+            resizedCacheKey = "\(url.absoluteString)_\(sizeKey)"
         }
 
-        self.kf.indicatorType = isIndicator ? .custom(indicator: CustomKfActivityIndicator(indicator)) : .none
+        kf.indicatorType = isIndicator ? .custom(indicator: CustomKfActivityIndicator(indicator)) : .none
         if isIndicator {
-            self.kf.indicator?.startAnimatingView()
+            kf.indicator?.startAnimatingView()
         }
+
+        let resource = KF.ImageResource(
+            downloadURL: url,
+            cacheKey: resizedCacheKey
+        )
 
         // 🌄 이미지 로드 시작
-        self.kf.setImage(
-            with: url,
+        kf.setImage(
+            with: resource,
             placeholder: placeholder,
             options: kfOptions
         ) { [weak self] result in

--- a/Sources/Function/DebugLoggerManager.swift
+++ b/Sources/Function/DebugLoggerManager.swift
@@ -38,7 +38,8 @@ public func DebugLog(_ message: Any? = "",
                      funcName: String = #function,
                      line: Int = #line,
                      param: [String: Any] = [:],
-                     isDebugPrint: Bool = false) {
+                     isDebugPrint: Bool = false,
+                     isFileLog: Bool = true) {
     if isDebugPrint {
         let fileName: String = (file as NSString).lastPathComponent
         var fullMessage = """
@@ -79,6 +80,7 @@ public func DebugLog(_ message: Any? = "",
         }
     }
 
+    guard isFileLog else { return }
     switch level {
     case .debug,
             .error,
@@ -110,6 +112,15 @@ public final class DebugLoggerManager {
         removeOldLogsIfNeeded(force: true)
     }
 
+    // 디스크 여유 공간 조회
+    private func availableDiskSpace() -> UInt64 {
+        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory()),
+           let freeSize = attrs[.systemFreeSize] as? UInt64 {
+            return freeSize
+        }
+        return 0
+    }
+
     private func createDirectoryIfNeeded() {
         if !FileManager.default.fileExists(atPath: self.logDirectory.path) {
             try? FileManager.default.createDirectory(at: self.logDirectory, withIntermediateDirectories: true)
@@ -126,7 +137,7 @@ public final class DebugLoggerManager {
         let expirationDate = Calendar.current.date(byAdding: .day, value: -30, to: now)!
         guard let files = try? fileManager.contentsOfDirectory(at: self.logDirectory, includingPropertiesForKeys: [.creationDateKey]) else { return }
 
-        // 1. 삭제 대상: 30일 초과된 파일
+        // 1. 30일 이상된 파일 삭제
         for file in files {
             if let creationDate = try? file.resourceValues(forKeys: [.creationDateKey]).creationDate,
                creationDate < expirationDate {
@@ -134,7 +145,7 @@ public final class DebugLoggerManager {
             }
         }
 
-        // 2. 디렉토리 전체 용량 검사
+        // 2. 전체 용량 초과 시 오래된 것부터 제거
         var remainingFiles = getAllLogFiles().sorted { lhs, rhs in
             let lhsDate = (try? lhs.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
             let rhsDate = (try? rhs.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
@@ -180,13 +191,22 @@ public final class DebugLoggerManager {
     }
 
     public func log(_ message: Any?,
-             level: DebugLogLevel,
-             file: String,
-             funcName: String,
-             line: Int,
-             param: [String: Any]) {
+                    level: DebugLogLevel,
+                    file: String,
+                    funcName: String,
+                    line: Int,
+                    param: [String: Any]) {
 
-        logQueue.async {
+        logQueue.async { [weak self] in
+            guard let self = self else { return }
+            // ✅ (2) 디스크 여유 공간이 1GB 미만이면 로그 기록 자체 중지
+            let freeSpace = self.availableDiskSpace()
+            if freeSpace < 1_000_000_000 {
+                self.removeOldLogsIfNeeded(force: true)
+                return
+            }
+
+            // ✅ (1) 로그 쓰기 전에 오래된 로그 정리
             self.removeOldLogsIfNeeded()
 
             let date = Date()
@@ -204,14 +224,17 @@ public final class DebugLoggerManager {
             let logFileURL = self.getLogFileURL()
 
             if let data = logEntry.data(using: .utf8) {
-                if FileManager.default.fileExists(atPath: logFileURL.path) {
+                do {
                     if let fileHandle = try? FileHandle(forWritingTo: logFileURL) {
                         defer { fileHandle.closeFile() }
                         fileHandle.seekToEndOfFile()
                         fileHandle.write(data)
+                    } else {
+                        try data.write(to: logFileURL)
                     }
-                } else {
-                    try? data.write(to: logFileURL)
+                } catch {
+                    // ✅ (1) 디스크 가득 참 → 기존 로그 제거 후 기록 시도 or 그냥 skip
+                    try? FileManager.default.removeItem(at: logFileURL)
                 }
             }
         }
@@ -227,18 +250,22 @@ public final class DebugLoggerManager {
 
         try? fileManager.removeItem(at: zipFileURL)
 
-        let logFiles = getAllLogFiles()
+        let logFiles = getAllLogFiles().filter { $0.lastPathComponent != "logs.zip" }
         guard !logFiles.isEmpty else { return nil }
 
         do {
             let archive = try Archive(url: zipFileURL, accessMode: .create)
             // archive 사용
             for file in logFiles {
-                try? archive.addEntry(with: file.lastPathComponent, relativeTo: logDirectory)
+                do {
+                    try archive.addEntry(with: file.lastPathComponent, relativeTo: logDirectory)
+                } catch {
+                    DebugLog("Failed to add \(file.lastPathComponent) to archive: \(error)", level: .error, isFileLog: false)
+                }
             }
             return zipFileURL
         } catch {
-            DebugLog("Failed to create archive: \(error)", level: .error)
+            DebugLog("Failed to create archive: \(error)", level: .error, isFileLog: false)
             return nil
         }
     }

--- a/Sources/Function/NetworkConnectivityManager.swift
+++ b/Sources/Function/NetworkConnectivityManager.swift
@@ -5,10 +5,11 @@
 // Created by Dongju Lim on 10/11/24.
 //
 import Foundation
-import Alamofire
 import Combine
 import UIKit
 
+#if canImport(Alamofire)
+import Alamofire
 public typealias NetworkStatusCode = NetworkReachabilityManager.NetworkReachabilityStatus
 public protocol NetworkReachabilityManagerProtocol: AnyObject {
     func startReachabilityListening(onQueue queue: DispatchQueue, onUpdatePerforming listener: @escaping (NetworkStatusCode) -> Void)
@@ -73,3 +74,4 @@ public final class NetworkConnectivityManager {
         networkReachabilityManager?.stopListening()
     }
 }
+#endif

--- a/Sources/MoyaNetwork/BaseNetworkLoggingPlugin.swift
+++ b/Sources/MoyaNetwork/BaseNetworkLoggingPlugin.swift
@@ -8,7 +8,6 @@
 import Foundation
 #if canImport(Moya)
 import Moya
-#endif
 /// 네트워크 호출 결과 로그 표시
 public typealias APILoggingConfiguration = NetworkLoggerPlugin.Configuration
 public class BaseNetworkLoggingPlugin: PluginType {
@@ -115,3 +114,4 @@ extension BaseNetworkLoggingPlugin {
         return [configuration.formatter.entry("Error", "Error calling \(target) : \(error)", target)]
     }
 }
+#endif


### PR DESCRIPTION
1. 사용자 디스크 용량이 없을때 파일 쓰기를 하면 크래시가 발생 할 수 있음. 로그 기록시 여유 공간을 체크하고 로그를 기록하도록 코드를 개선함.
2. Kingfisher의 인디케이터를 사용하기 전에 UIImageView의 subviews를 확인하여 기존 인디케이터 뷰가 있다면 제거하는 코드를 추가합니다. Kingfisher는 자체적으로 인디케이터 뷰를 관리하지만, UICollectionViewCell과 같은 재사용 가능한 뷰에서는 이전 상태의 뷰가 남아있을 수 있으므로 명시적으로 초기화해주는 것이 안전합니다. 인디게이터 커스텀 뷰를 제거하는 코드를 추가함.
3. 이미지를 표시할때 픽셀 해상도를 기준으로 이미지를 처리해서 뷰에 표시함. 이미지 파일 사이즈는 중요하지 않음. DownsamplingImageProcessor 사용하여 이미지 뷰 사이즈만큼 줄여서 처리하도록 코드 수정함
4. html 관련 코드 추가
5. json이 아닌 xml 타입의 데이터 로깅을 위한 코드 수정
6. Kingfisher 관련 리사이즈 코드 개선